### PR TITLE
Updates Vagrant file with new urls

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,9 +6,9 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "modules", "/tmp/puppet-modules", type: "rsync", rsync__exclude: ".git/"
   config.vm.synced_folder ".", "/tmp/puppet-modules/influxdb", type: "rsync", rsync__exclude: ".git/"
 
-  config.vm.define "centos" do |centos|
+  config.vm.define "centos", primary: true do |centos|
     centos.vm.box     = 'centos64'
-    centos.vm.box_url = 'http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210.box'
+    centos.vm.box_url = 'https://vagrantcloud.com/puppetlabs/boxes/centos-6.5-64-puppet/versions/3/providers/virtualbox.box'
     centos.vm.provision :puppet do |puppet|
       puppet.manifests_path = "tests"
       puppet.manifest_file  = "vagrant.pp"
@@ -16,9 +16,9 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.define "ubuntu" do |ubuntu|
+  config.vm.define "ubuntu", autostart: false do |ubuntu|
     ubuntu.vm.box     = 'ubuntu64'
-    ubuntu.vm.box_url = 'http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box'
+    ubuntu.vm.box_url = 'https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-puppet/versions/3/providers/virtualbox.box'
     ubuntu.vm.provision :puppet do |puppet|
       puppet.manifests_path = "tests"
       puppet.manifest_file  = "vagrant.pp"


### PR DESCRIPTION
Adds updated urls that use the new vagrant butt images. I tried to use as simliar as possible to the exisitng boxes (puppet labs + puppet installed)
If user omits the flavor of OS to start, vagrant no longer attempts to start both instances. 

Fixes https://github.com/justindowning/puppet-influxdb/issues/6
