### PR TITLE
Optional Admin section & avoid timeout failure

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,12 @@
 # == Class: influxdb::config
 # More information on these settings available at: http://influxdb.org/docs/configuration.html
 class influxdb::config {
+  $admin_presence = $admin_port ? {
+    ""      => absent,
+    undef   => absent,
+    default => present,
+  }
+
   ini_setting { 'hostname':
     section => '',
     setting => 'hostname',
@@ -28,12 +34,14 @@ class influxdb::config {
 
   # [admin]
   ini_setting { 'admin_port':
+    ensure  => $admin_presence,
     section => 'admin',
     setting => 'port',
     value   => $influxdb::admin_port,
   }
 
   ini_setting { 'admin_assets':
+    ensure  => $admin_presence,
     section => 'admin',
     setting => 'assets',
     value   => "\"${influxdb::admin_assets}\"",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,12 @@ class influxdb::config {
     default => present,
   }
 
+  ini_setting { 'reporting_disabled':
+    section => '',
+    setting => 'reporting-disabled',
+    value   => $influxdb::reporting_disabled,
+  }
+
   ini_setting { 'hostname':
     section => '',
     setting => 'hostname',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class influxdb (
   $wal_bookmark_after                   = $influxdb::params::wal_bookmark_after,
   $wal_index_after                      = $influxdb::params::wal_index_after,
   $wal_requests_per_logfile             = $influxdb::params::wal_requests_per_logfile,
+  $reporting_disabled                   = $influxdb::params::reporting_disabled,
 ) inherits influxdb::params {
 
   class { 'influxdb::config': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,6 +29,8 @@ class influxdb::install {
     # get the package
     staging::file { 'influxdb-package':
       source   => $package_source,
+      tries   => 3,
+      timeout => 0,
     }
 
     # install the package

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,6 @@ class influxdb::install {
     # get the package
     staging::file { 'influxdb-package':
       source   => $package_source,
-      tries   => 3,
       timeout => 0,
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,4 +58,7 @@ class influxdb::params {
   $wal_bookmark_after                   = '0'
   $wal_index_after                      = '1000'
   $wal_requests_per_logfile             = '10000'
+
+  # [reporting]
+  $reporting_disabled                   = false
 }


### PR DESCRIPTION
If I check for presence of admin_port I can make it conditional for production installations where the admin port does not have to be exposed. 
