### PR TITLE
[Feature] Support Graphite input plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ you have any ideas or contributions, feel free to open a pull request!
 
 Most of the configuration is parameterized, so you can freely adjust settings.
 
+### Configuring InfluxDB input plugins
+
+The module currently supports enabling and configuring the Graphite input plugin (PRs welcome):
+
+```
+class {'influxdb::input_plugins::graphite':
+  database => 'graphite',
+}
+```
+
 ## Testing
 
 ```

--- a/manifests/input_plugins/graphite.pp
+++ b/manifests/input_plugins/graphite.pp
@@ -1,0 +1,54 @@
+# == Class: influxdb::input_plugins::graphite
+#
+# This class enables support for the InfluxDB graphite input plugin.
+#
+# == Parameters:
+#
+# $database:: The *existing* databse to use for Graphite plugin inputs.
+#             Required.
+# $port::     The port to listen to for inputs. Defaults to 2003 which is
+#             standard Graphite behaviour.
+# $enabled::  Should the Graphite plugin be enabled (default: 'true'). Useful
+#             mainly for disabling the plugin.
+#
+# == Sample Usage:
+#
+# class {'influxdb::input_plugins::graphite':
+#   database => 'graphite',
+# }
+#
+# class {'influxdb::input_plugins::graphite':
+#   database => 'graphite',
+#   port     => 9000,
+# }
+#
+class influxdb::input_plugins::graphite(
+  $database,
+  $port = 2003,
+  $enabled = 'true'){
+
+  Ini_setting {
+    ensure  => present,
+    path    => $influxdb::config_path,
+    notify  => Service['influxdb'],
+    require => Package['influxdb'],
+  }
+
+  ini_setting { 'input_plugins_graphite_enabled':
+    section => 'input_plugins.graphite',
+    setting => 'enabled',
+    value   => $enabled
+  }
+
+  ini_setting { 'input_plugins_graphite_port':
+    section => 'input_plugins.graphite',
+    setting => 'port',
+    value   => $port,
+  }
+
+  ini_setting { 'input_plugins_graphite_database':
+    section => 'input_plugins.graphite',
+    setting => 'database',
+    value   => "\"${database}\"",
+  }
+}

--- a/spec/classes/input_plugins_spec.rb
+++ b/spec/classes/input_plugins_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'influxdb::input_plugins::graphite' do
+  let(:title) {'input_plugins_graphite'}
+  
+  context 'with only database parameter' do
+    let(:params) { {:database => 'graphite'} }  
+    
+    context 'it should enable the plugin' do
+      it { should contain_ini_setting('input_plugins_graphite_enabled').with_section('input_plugins.graphite').with_setting('enabled') }
+      it { should contain_ini_setting('input_plugins_graphite_enabled').with_section('input_plugins.graphite').with_value('true') }
+    end
+    
+    context 'it should set the port to the default of 2003' do
+      it { should contain_ini_setting('input_plugins_graphite_port').with_section('input_plugins.graphite').with_setting('port') }
+      it { should contain_ini_setting('input_plugins_graphite_port').with_section('input_plugins.graphite').with_value('2003') }
+    end
+    
+    context 'it should set the database name from the database parameter' do
+      it { should contain_ini_setting('input_plugins_graphite_database').with_section('input_plugins.graphite').with_setting('database') }
+      it { should contain_ini_setting('input_plugins_graphite_database').with_section('input_plugins.graphite').with_value('"graphite"') }
+    end
+  end
+
+  context 'with custom port' do
+    let(:params) { {
+        :database => 'graphite',
+        :port => 9999
+      } }
+    
+    context 'it should set the port number from the port parameter' do
+      it { should contain_ini_setting('input_plugins_graphite_port').with_section('input_plugins.graphite').with_setting('port') }
+      it { should contain_ini_setting('input_plugins_graphite_port').with_section('input_plugins.graphite').with_value('9999') }
+    end
+  end
+    
+  context 'with enabled => false' do
+    let(:params) { {
+        :database => 'graphite',
+        :enabled => false
+      } }
+
+    context 'it should disable the plugin' do
+      it { should contain_ini_setting('input_plugins_graphite_enabled').with_section('input_plugins.graphite').with_setting('enabled') }
+      it { should contain_ini_setting('input_plugins_graphite_enabled').with_section('input_plugins.graphite').with_value('false') }
+    end
+  end
+end


### PR DESCRIPTION
Enables support for:
- database name
- input port
- disable plugin

closes #14, although it only supports one plugin at the moment.
Factor out common parts when supporting additional plugins.
