### PR TITLE
Rename unnamed point-write-size to write-batch-size

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -164,10 +164,10 @@ class influxdb::config {
     value   => $influxdb::leveldb_point_batch_size,
   }
 
-  ini_setting { 'leveldb_point_write_size':
+  ini_setting { 'leveldb_write_batch_size':
     section => 'leveldb',
-    setting => 'point-write-size',
-    value   => $influxdb::leveldb_point_write_size,
+    setting => 'write-batch-size',
+    value   => $influxdb::leveldb_write_batch_size,
   }
 
   # [sharding]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,7 +48,7 @@ class influxdb::params {
   $leveldb_lru_cache_size               = '200m'
   $leveldb_max_open_shards              = '0'
   $leveldb_point_batch_size             = '100'
-  $leveldb_point_write_size             = '5000000'
+  $leveldb_write_batch_size             = '5000000'
 
   # [sharding]
 


### PR DESCRIPTION
This PR corrects the usage of the levelDB point write size option.
